### PR TITLE
Multiplexer example with React

### DIFF
--- a/react_forked_event/build.sh
+++ b/react_forked_event/build.sh
@@ -2,7 +2,9 @@ source ../ocaml_env.sh
 
 $OCAMLFIND ocamlopt -package react -package unix -linkpkg -I ./ -o run.tsk \
     dispatcher.mli dispatcher.ml \
-    encoding.ml \
+    pipe_connection.mli pipe_connection.ml \
+    select.mli select.ml \
+    encoding.mli encoding.ml \
     fn.ml \
     forked_event.mli forked_event.ml \
     run.ml

--- a/react_forked_event/encoding.ml
+++ b/react_forked_event/encoding.ml
@@ -1,6 +1,5 @@
 
-module type Int_encoding_sig = sig 
-
+module Int_encoding : sig 
   val size : int 
   (** Fixed size of the encoding of an int in bytes *)
 
@@ -15,9 +14,8 @@ module type Int_encoding_sig = sig
 
       The function returns the int.
     *)
-end 
 
-module Int : Int_encoding_sig = struct 
+end = struct 
 
   let size = 4
     
@@ -51,6 +49,7 @@ module Fd_util : sig
 
       Function raises End_of_file if no bytes can be read from [fd].
    *)
+
 end = struct 
 
   let rec read fd buff start length =
@@ -65,54 +64,217 @@ end = struct
         | n -> read fd buff (start+n) (length-n);;
 end 
 
+let write_msg ?buf fd  s = 
+  let buf = match buf with 
+    | Some b -> b 
+    | None   -> Bytes.create Int_encoding.size in 
+  let l = String.length s in 
+  (* send the message size *)
+  let (_:unit) = Int_encoding.int_to_bytes_unsafe l buf 0 in 
+  let (actuall_written:int) = Unix.single_write fd buf 0 Int_encoding.size in
+  assert (actuall_written = Int_encoding.size);
+  (* send the message *) 
+  let (actuall_written:int)  = Unix.single_write_substring fd s 0 l in 
+  assert (actuall_written = l);
+  ()
 
-module Make (I:Int_encoding_sig) : sig
+let read_msg ?buf fd = 
+  
+  let buf1 =  match buf with 
+    | Some b -> b
+    | None   -> Bytes.create Int_encoding.size in 
+  
+  (* read the message size *)
+  Fd_util.read fd buf1 0 Int_encoding.size; 
+  let string_size = Int_encoding.int_of_bytes buf1 0 in 
 
-  val write_msg : ?buf:bytes -> Unix.file_descr  -> string -> unit 
-  (** [write_msg ~buf fd s] will write the string [s] on the 
-      [fd]. The optional argument [buf] can be used by the client 
-      to improve speed performance to avoid re-creating 
-      temporary buffer. The buffer should be at least I.size in available
-      length.
-    *) 
+  (* read the message *) 
+  let buf2, offset2 = match buf with 
+    | Some b -> b, Int_encoding.size 
+    | None -> Bytes.create string_size, 0  in 
+  Fd_util.read fd buf2 offset2 string_size; 
+  Bytes.sub_string buf2 offset2 string_size
 
-  val read_msg : ?buf:bytes -> Unix.file_descr -> string 
-  (** [read_msg ~buf fd] will read a string encoding using the [write_msg] 
-      function. 
-      
-    *) 
+  
+type fork_connection = < 
+  write_fd: Unix.file_descr;
+  write   : string -> unit; 
+  read_fd : Unix.file_descr; 
+  read    : string; 
+> 
 
-end = struct 
+type fork = 
+    | Child  of fork_connection  
+    | Parent of int * fork_connection 
 
-  let write_msg ?buf fd  s = 
-    let buf = match buf with 
-      | Some b -> b 
-      | None   -> Bytes.create I.size in 
-    let l = String.length s in 
+let fork () = 
+    let pc = Pipe_connection.create () in 
+    match Unix.fork () with
+    | 0 -> 
+        Pipe_connection.set `P1 pc; 
+        Child  (object(this) 
+        method write_fd = Pipe_connection.write_fd `P1 pc; 
+        method write s = write_msg this#write_fd s  
+        method read_fd = Pipe_connection.read_fd `P1 pc; 
+        method read = read_msg this#read_fd; 
+    end) 
+    | childpid -> 
+        Pipe_connection.set `P2 pc; 
+        Parent (childpid, (object(this) 
+        method write_fd = Pipe_connection.write_fd `P2 pc; 
+        method write s = write_msg this#write_fd s  
+        method read_fd = Pipe_connection.read_fd `P2 pc; 
+        method read = read_msg this#read_fd; 
+    end)) 
 
-    (* send the message size *)
-    let (_:unit) = I.int_to_bytes_unsafe l buf 0 in 
-    let (actuall_written:int) = Unix.single_write fd buf 0 I.size in
-    assert (actuall_written = I.size);
-    (* send the message *) 
-    let (actuall_written:int)  = Unix.single_write_substring fd s 0 l in 
-    assert (actuall_written = l);
-    ()
 
-  let read_msg ?buf fd = 
+type selector = {
+    selector : Select.selector; 
+    holder   : (unit React.event) list ref; 
+} 
+
+let create () = {
+    selector = Select.create (); 
+    holder   = ref [];
+}
+
+type read_value = 
+    | String of string 
+    | Closed
+
+
+let add_read fork_connection {selector; holder; } = 
     
-    let buf1 =  match buf with 
-      | Some b -> b
-      | None   -> Bytes.create I.size in 
-    
-    (* read the message size *)
-    Fd_util.read fd buf1 0 I.size; 
-    let string_size = I.int_of_bytes buf1 0 in 
+    let read_ready_e = Select.add_in fork_connection#read_fd selector in 
 
-    (* read the message *) 
-    let buf2, offset2 = match buf with 
-      | Some b -> b, I.size 
-      | None -> Bytes.create string_size, 0  in 
-    Fd_util.read fd buf2 offset2 string_size; 
-    Bytes.sub_string buf2 offset2 string_size
-end 
+    let on_close read_fd = 
+        Select.remove_in read_fd selector; 
+        Some Closed
+    in
+
+    let len = ref 4 in  
+    let buf = ref @@ Bytes.create !len in  
+
+    let check_buf string_size = 
+        let overflow = !len - Int_encoding.size - string_size in 
+        if overflow < 0 
+        then ( 
+            buf := Bytes.extend !buf 0 (- overflow);
+            len := Bytes.length !buf 
+        )
+    in 
+
+    let remaining = ref None in 
+
+    let read_new_string read_fd = 
+        match Unix.read read_fd !buf 0 Int_encoding.size with
+        | 0 -> on_close read_fd
+        | i when i = Int_encoding.size -> (
+            let string_size = Int_encoding.int_of_bytes !buf 0 in 
+            check_buf string_size; 
+            match Unix.read read_fd !buf Int_encoding.size (string_size) with 
+            | i when i = string_size -> ( 
+                let s = Bytes.sub_string !buf Int_encoding.size string_size in 
+                Some (String s)
+            )
+            | 0 -> on_close read_fd
+            | x -> (
+                remaining := Some (string_size - x, x); 
+                None
+            ) 
+        )
+        | x -> failwith @@ Printf.sprintf "Failed to read msg size (%i)" x
+    in 
+    
+    let read_remaining read_fd (remaining_n, read_n) = 
+        match Unix.read read_fd !buf read_n remaining_n with
+        | 0 -> on_close read_fd
+        | i when i = remaining_n -> (
+            remaining := None; 
+            let s = Bytes.sub_string !buf Int_encoding.size (read_n + remaining_n) in  
+            Some (String s) 
+        )
+        | n -> (
+            remaining := Some ((remaining_n - n), (read_n + n)); 
+            None 
+        )
+    in
+
+    let msg_e = React.E.fmap (fun read_fd -> 
+        match !remaining with 
+        | None   -> read_new_string read_fd 
+        | Some r -> read_remaining  read_fd r 
+    ) read_ready_e in 
+
+    holder:=(React.E.fmap (fun _ -> None) msg_e)::!holder;
+    
+    msg_e
+
+let add_write fork_connection {selector; holder} = 
+    let buf = Bytes.create 4 in 
+
+    let msg_queue      = ref [] in 
+    (* all the msg waiting to be sent *)
+
+    let remaining_write = ref None in  
+    (* the information to keep track of a partial read. When the 
+       file descriptor becomes readily available the 
+       remaining data is then rather than the next msg in the queue. 
+     *)
+
+    let write_new_msg write_fd = 
+        match !msg_queue with 
+        | []       -> failwith "Programatic error [write_msg_queue is empty]"
+        | msg::tl  -> (
+            let l = String.length msg in 
+            Int_encoding.int_to_bytes_unsafe l buf 0;
+            let written = Unix.single_write write_fd buf 0 Int_encoding.size in
+            assert (written = Int_encoding.size);
+            match Unix.single_write_substring write_fd msg  0 l with 
+            | x when x = l -> ( msg_queue :=tl )
+            | n            -> ( remaining_write := Some (msg, tl, n, l - n) 
+            )
+        );
+    in
+
+    let write_remaining write_fd (msg, tl, encoded_n, len) = 
+        match Unix.single_write_substring write_fd msg encoded_n len with 
+        | x when x = len -> (
+            remaining_write := None ; 
+            msg_queue := tl
+        ) 
+        | n -> remaining_write := Some (msg, tl, encoded_n + n, len - n)
+    in 
+    
+    let write_f msg = 
+        msg_queue := !msg_queue @ [msg];
+        if List.length !msg_queue = 1
+        then ( 
+            (* When a brand new msg is added this is when we need to start
+              listening to the file descriptor availability
+             *)
+            let write_ready_e = Select.add_out fork_connection#write_fd selector in  
+            let write_e = React.E.map (fun write_fd -> 
+                (match !remaining_write with 
+                | Some r -> write_remaining write_fd r 
+                | None   -> write_new_msg write_fd);
+                if !msg_queue = [] 
+                then Select.remove_out write_fd selector
+                else ()
+            ) write_ready_e in 
+            holder := write_e :: !holder; 
+        )
+        else () 
+    in  
+    write_f 
+
+let add_fork_connection fork_connection s = 
+    let msg_e = add_read fork_connection s in  
+    let write_f = add_write fork_connection s in 
+    (write_f, msg_e) 
+     
+let select timeout {selector;} = 
+    Select.select timeout selector
+
+let nb_of_writes {selector; _ }  = 
+    Select.nb_of_writes selector 

--- a/react_forked_event/encoding.mli
+++ b/react_forked_event/encoding.mli
@@ -1,0 +1,40 @@
+
+val write_msg : ?buf:bytes -> Unix.file_descr  -> string -> unit 
+(** [write_msg ~buf fd s] will write the string [s] on the 
+    [fd]. The optional argument [buf] can be used by the client 
+    to improve speed performance to avoid re-creating 
+    temporary buffer. The buffer should be at least I.size in available
+    length.
+ *) 
+
+val read_msg : ?buf:bytes -> Unix.file_descr -> string 
+(** [read_msg ~buf fd] will read a string encoding using the [write_msg] 
+    function. 
+  *) 
+
+type fork_connection = < 
+  write_fd: Unix.file_descr;
+  write   : string -> unit; 
+  read_fd : Unix.file_descr; 
+  read    : string ;
+> 
+
+type fork = 
+    | Child  of fork_connection  
+    | Parent of int * fork_connection 
+
+val fork : unit -> fork 
+
+type selector 
+
+val create : unit -> selector 
+
+type read_value = 
+    | String of string 
+    | Closed 
+
+val add_fork_connection : fork_connection -> selector -> ((string -> unit) * (read_value React.event))  
+
+val select : float -> selector -> Select.select_status 
+
+val nb_of_writes : selector -> int 

--- a/react_forked_event/forked_event.ml
+++ b/react_forked_event/forked_event.ml
@@ -87,7 +87,6 @@ module E = struct
     if e = React.E.never || P_handle.is_locked parent_handle
     then e, C_handle.noop
     else 
-      let module Encoding = Encoding.Make(Encoding.Int) in 
       let fd_read, fd_write = Unix.pipe () in 
       match Unix.fork () with 
       | 0 ->                                    (** child process *) 

--- a/react_forked_event/pipe_connection.ml
+++ b/react_forked_event/pipe_connection.ml
@@ -1,0 +1,27 @@
+
+type t = {
+  fd_server_read : Unix.file_descr; 
+  fd_server_write : Unix.file_descr; 
+  fd_client_read : Unix.file_descr; 
+  fd_client_write : Unix.file_descr; 
+}
+
+let create () =
+    let fd_server_read, fd_client_write = Unix.pipe () in 
+    let fd_client_read, fd_server_write = Unix.pipe () in 
+    {fd_server_write;fd_client_read; fd_client_write; fd_server_read } 
+
+let set as_ pc = 
+    match as_ with 
+    | `P1 -> (Unix.close pc.fd_server_write; Unix.close pc.fd_server_read;)
+    | `P2 -> (Unix.close pc.fd_client_write; Unix.close pc.fd_client_read;)
+
+let read_fd as_ pc = 
+    match as_ with
+    | `P1 -> pc.fd_client_read 
+    | `P2 -> pc.fd_server_read 
+
+let write_fd as_ pc = 
+    match as_ with
+    | `P1 -> pc.fd_client_write 
+    | `P2 -> pc.fd_server_write 

--- a/react_forked_event/pipe_connection.mli
+++ b/react_forked_event/pipe_connection.mli
@@ -1,0 +1,18 @@
+
+type t 
+(** double pipe connection allowing 2 sided read/writes *)
+
+val create : unit -> t 
+(** [create ()] @returns a new pipe connection *)
+
+val set : [`P1 | `P2 ]  -> t -> unit 
+(** [set process t] closes the unused file descriptors from each side 
+    of the pipe. This function must be called after the fork in both 
+    parent and child process but with different [process] values.
+ *)
+
+val read_fd : [`P1 | `P2 ] -> t -> Unix.file_descr 
+(** [read_fd process t] returns the read file descriptor *)
+
+val write_fd : [`P1 | `P2] -> t -> Unix.file_descr 
+(** [write_fd process t] returns the write file descriptor *)

--- a/react_forked_event/run.ml
+++ b/react_forked_event/run.ml
@@ -1,162 +1,247 @@
 
-let debug = true 
+let debug = true
 
-module Prime = struct  
+module Prime = struct
 
-  let not_divisible n l = 
+  let not_divisible n l =
     for i=0 to 100 do
-        ignore @@ not @@ List.exists (fun m -> n mod m = 0) l 
+        ignore @@ not @@ List.exists (fun m -> n mod m = 0) l
     done;
-    not @@ List.exists (fun m -> n mod m = 0) l 
+    not @@ List.exists (fun m -> n mod m = 0) l
 
-  let print_prime n = 
-      if debug 
-      then Printf.printf "[%6i] prime found: %5i \n%!" (Unix.getpid()) n  
-      else () 
-      
-  let print_to_file_prime = Fn.run 
-    (fun () -> 
-      let name = Printf.sprintf "./logs/prime%i.txt" (Unix.getpid()) in 
+  let print_prime n =
+      if debug
+      then Printf.printf "[%6i] prime found: %5i \n%!" (Unix.getpid()) n
+      else ()
+
+  let print_to_file_prime = Fn.run
+    (fun () ->
+      let name = Printf.sprintf "./logs/prime%i.txt" (Unix.getpid()) in
       open_out name)
-    (fun oc n -> Printf.fprintf oc "%5i\n%!" n; flush oc) 
+    (fun oc n -> Printf.fprintf oc "%5i\n%!" n; flush oc)
 
-  exception Sequence_done 
+  exception Sequence_done
 
-  let create_counter_event k = 
-    let e, send = React.E.create () in 
-    let counter = ref 2 in  
-    let counter_send ?step () = 
+  let create_counter_event k =
+    let e, send = React.E.create () in
+    let counter = ref 2 in
+    let counter_send ?step () =
       if !counter = k
-      then 
-        raise Sequence_done 
+      then
+        raise Sequence_done
       else begin
-        if debug 
+        if debug
         then (
-          Unix.sleep 1; 
+          Unix.sleep 1;
           Printf.printf "[%6i] sending %5i \n%!" (Unix.getpid ()) !counter
         )
         else ();
-        
-        send ?step !counter; 
-        counter:=!counter+1; 
+
+        send ?step !counter;
+        counter:=!counter+1;
       end
     in
     e, counter_send
-  
-  let create_read_prime ?nth when_prime_f int_event = 
-    let first_primes = ref [] in  
-    let len          = ref 0 in 
-    React.E.fmap (fun n -> 
-      if not_divisible n !first_primes 
-      then 
-        let handle_prime () = 
-          when_prime_f n; 
-          first_primes := n:: !first_primes; 
-          len := !len + 1;  
+
+  let create_read_prime ?nth when_prime_f int_event =
+    let first_primes = ref [] in
+    let len          = ref 0 in
+    React.E.fmap (fun n ->
+      if not_divisible n !first_primes
+      then
+        let handle_prime () =
+          when_prime_f n;
+          first_primes := n:: !first_primes;
+          len := !len + 1;
           None
-        in 
-        match nth with 
-        | None -> handle_prime () 
-        | Some nth -> ( 
-          if !len >= nth 
-          then Some n 
-          else handle_prime () 
+        in
+        match nth with
+        | None -> handle_prime ()
+        | Some nth -> (
+          if !len >= nth
+          then Some n
+          else handle_prime ()
         )
       else None
     ) int_event
-end 
+end
 
 let print_banner s=
-  let open Printf in 
-  printf "----------------------\n";  
+  let open Printf in
+  printf "----------------------\n";
   printf "----%5s----\n" s;
-  printf "----------------------\n";  
+  printf "----------------------\n";
   ()
 
-let run_01 ()  = 
-   
+let run_01 ()  =
+
    print_banner "test 1";
    flush stdout;
-  
-  let counter_size = 12 in 
 
-  let ph = Forked_event.P_handle.create () in 
+  let counter_size = 12 in
+
+  let ph = Forked_event.P_handle.create () in
 
   let fork_event (e, step_functions) =
-    let e, send = Forked_event.E.create ph e string_of_int int_of_string in 
+    let e, send = Forked_event.E.create ph e string_of_int int_of_string in
     e, send::step_functions
-  in 
+  in
 
-  let create_counter_event sf = 
+  let create_counter_event sf =
       let e, send = Prime.create_counter_event counter_size  in
       e, Forked_event.C_handle.of_send send :: sf
-  in 
+  in
 
-  let read_prime ?nth (int_event, sf) = 
+  let read_prime ?nth (int_event, sf) =
       Prime.create_read_prime ?nth Prime.print_prime int_event, sf
-  in 
+  in
 
   let (_, sf) = (
       create_counter_event []
     |> read_prime ~nth:1
-    |> fork_event 
+    |> fork_event
     |> read_prime ~nth:1
-    |> fork_event 
+    |> fork_event
     |> read_prime ~nth:1
-    |> fork_event 
-    |> read_prime 
+    |> fork_event
+    |> read_prime
   )
   in
-  
+
   try
-    while true do 
-      let step = React.Step.create () in 
-      List.iter (fun pidd -> Forked_event.C_handle.send pidd ~step ()) sf; 
+    while true do
+      let step = React.Step.create () in
+      List.iter (fun pidd -> Forked_event.C_handle.send pidd ~step ()) sf;
       React.Step.execute step
-    done 
-  with exn -> ( 
-      Printf.eprintf "[%6i] : %s \n%!" (Unix.getpid ()) (Printexc.to_string exn); 
-      List.iter (fun pidd -> Forked_event.C_handle.terminate pidd) sf 
+    done
+  with exn -> (
+      Printf.eprintf "[%6i] : %s \n%!" (Unix.getpid ()) (Printexc.to_string exn);
+      List.iter (fun pidd -> Forked_event.C_handle.terminate pidd) sf
   )
 
-let run_02 () = 
-  
+let run_02 () =
+
   print_banner "test 2";
   flush stdout;
 
-  let counter_event, counter_send = Prime.create_counter_event 12 in 
+  let counter_event, counter_send = Prime.create_counter_event 12 in
   (*
-  let small_printer = React.E.map (fun x -> Printf.printf "d:%i\n" x) counter_event in  
+  let small_printer = React.E.map (fun x -> Printf.printf "d:%i\n" x) counter_event in
   *)
-  let counter_send      = Forked_event.C_handle.of_send counter_send in 
-  let dispatched_events = Dispatcher.dispatch counter_event 4 in  
-  let dispatched_events = Array.map (fun e -> 
+  let counter_send      = Forked_event.C_handle.of_send counter_send in
+  let dispatched_events = Dispatcher.dispatch counter_event 4 in
+  let dispatched_events = Array.map (fun e ->
     (e, Forked_event.C_handle.noop)
-    ) dispatched_events in  
-  
-  let ph                = Forked_event.P_handle.create () in 
-  let forked_events     = Forked_event.P_handle.lock ph (fun () -> 
-    Array.map (fun (e,_)  -> 
-      Forked_event.E.create ph e string_of_int int_of_string
-    ) dispatched_events)  in 
+    ) dispatched_events in
 
-  let printed_events = Array.map (fun (e,ppid) -> 
+  let ph                = Forked_event.P_handle.create () in
+  let forked_events     = Forked_event.P_handle.lock ph (fun () ->
+    Array.map (fun (e,_)  ->
+      Forked_event.E.create ph e string_of_int int_of_string
+    ) dispatched_events)  in
+
+  let printed_events = Array.map (fun (e,ppid) ->
     React.E.map (fun x -> Printf.printf "[%6i] received %4i\n%!" (Unix.getpid ()) x) e, ppid
-    ) forked_events in 
-   
-  let all_send = counter_send::(Array.to_list @@ Array.map snd printed_events) in 
-  
+    ) forked_events in
+
+  let all_send = counter_send::(Array.to_list @@ Array.map snd printed_events) in
+
   try
-    while true do 
-      let step = React.Step.create () in 
-      List.iter (fun pidd -> Forked_event.C_handle.send pidd ~step ()) all_send; 
+    while true do
+      let step = React.Step.create () in
+      List.iter (fun pidd -> Forked_event.C_handle.send pidd ~step ()) all_send;
       React.Step.execute step
-    done 
-  with exn -> ( 
-      Printf.eprintf "[%6i] : %s \n%!" (Unix.getpid ()) (Printexc.to_string exn); 
-      List.iter (fun pidd -> 
+    done
+  with exn -> (
+      Printf.eprintf "[%6i] : %s \n%!" (Unix.getpid ()) (Printexc.to_string exn);
+      List.iter (fun pidd ->
         Forked_event.C_handle.terminate pidd) all_send
   )
 
-let () = 
-  run_02 () 
+let holder = ref []
+
+let run_03 () =
+
+    let nb_of_child = 100 in
+
+    let selector = Encoding.create () in
+
+    let events =
+        let rec loop events = function
+        | 0 -> events
+        | i -> (
+            match Encoding.fork () with
+            | Encoding.Child connection -> (
+                Random.self_init ();
+                (*Unix.sleep (Random.int 3 + 1); 
+                 *)
+                let selector     = Encoding.create () in 
+                let write_msg, _ = Encoding.add_fork_connection connection selector in 
+                for i=1 to 100  do
+                    let len = Random.int 100_000 + 10 in 
+                    let len = 100_000 in 
+                    let c   = Char.chr @@ Random.int 20 + 65 in 
+                    let msg = String.make len c in 
+                    write_msg msg 
+                done;
+                let rec loop () = 
+                    match Encoding.select 0.1 selector with 
+                    | Select.Timeout | Select.No_fds -> (
+                        if Encoding.nb_of_writes selector = 0 
+                        then (
+                            Printf.printf "Child [%10i] exiting\n%!" (Unix.getpid()) ; 
+                            exit 0 
+                        )
+                        else loop ()
+                    )
+                    | Select.Event_happened -> loop ()  
+                in 
+                loop () 
+            )
+            | Encoding.Parent (childpid , connection) -> (
+                Unix.close connection#write_fd;
+                let _, event = Encoding.add_fork_connection connection selector in
+                let event = React.E.map (fun read_value -> 
+                    (*Printf.printf "read_event from [%10i]\n%!" childpid;
+                     *)
+                    (childpid, read_value)) event in  
+                loop ((event)::events) (i - 1)
+                )
+            )
+        in
+        loop [] nb_of_child
+    in
+
+    let merger_e = React.E.merge (fun (l:string list) (childpid, read_value) ->  
+        match read_value with 
+        | Encoding.String s -> 
+            let len = String.length s in 
+            (Printf.sprintf "child [%6i] received : [%10i]" childpid len)::l  
+        | Encoding.Closed   -> l
+    ) [] events in
+
+    let counter_s =
+        let e = React.E.merge (fun i (_, read_value) -> match read_value with 
+            | Encoding.Closed   -> i+1
+            | Encoding.String _ -> i ) 0 events in
+        let e = React.E.fold (fun n i -> n  - i) nb_of_child e in
+        React.S.hold nb_of_child e in
+
+    let merger_e = React.E.fmap (function | [] -> None | l -> Some l) merger_e in
+
+    let (printer:unit React.event) = React.E.map (fun l ->
+        print_endline @@ String.concat "," l;
+        print_endline "-----------------";
+        flush stdout
+    ) merger_e in
+
+    holder := printer::!holder; 
+
+    while React.S.value counter_s <> 0 do
+        let (_:Select.select_status) = Encoding.select 1. selector in 
+        ()
+    done;
+    ()
+
+let () =
+  run_03 ()

--- a/react_forked_event/select.ml
+++ b/react_forked_event/select.ml
@@ -1,0 +1,69 @@
+
+type event_handler = (?step:React.step -> Unix.file_descr -> unit) 
+
+type selector_i  = {
+    in_fds : (Unix.file_descr * event_handler) list ;
+    out_fds : (Unix.file_descr * event_handler) list ;
+} 
+
+type selector = selector_i ref 
+
+let create () = ref {in_fds = [] ; out_fds = [] } 
+
+let add_in fd selector = 
+    let {in_fds; _ } as selector_i = !selector in  
+    let e, event_handler = React.E.create () in 
+    selector := {selector_i with in_fds = (fd, event_handler)::in_fds}; 
+    e 
+
+let remove_in fd selector = 
+    let {in_fds; _ } as selector_i = !selector in  
+    selector := {selector_i with in_fds = List.filter (fun x -> fst x<> fd) in_fds} 
+
+let add_out fd selector = 
+    let {out_fds; _ } as selector_i = !selector in  
+    let e, event_handler = React.E.create () in 
+    selector := {selector_i with out_fds = (fd, event_handler)::out_fds}; 
+    e 
+
+let remove_out fd selector = 
+    let {out_fds; _ } as selector_i = !selector in  
+    selector := {selector_i with out_fds = List.filter (fun x -> fst x <> fd) out_fds} 
+
+type select_status = 
+    | Timeout 
+    | Event_happened 
+    | No_fds 
+
+let select timeout selector  = 
+    let {in_fds; out_fds; } = !selector in 
+    
+    if List.length in_fds = 0 && List.length out_fds = 0 
+    then No_fds
+    else 
+        let get_fds x = List.map fst x in 
+    
+        let in_fds', out_fds', _ = 
+            Unix.select (get_fds in_fds) (get_fds out_fds) [] timeout in   
+        
+        let step = React.Step.create () in 
+        let trigger handlers = List.fold_left (fun () fd -> 
+            try 
+                let (handler:event_handler) = List.assoc fd handlers in  
+                let (_:unit) = handler ~step fd in 
+                ()  
+            with Not_found -> failwith "Programmatic error"
+        ) () 
+        in 
+
+        let (_:unit) = trigger in_fds in_fds' in 
+        let (_:unit) = trigger out_fds out_fds' in
+        let (_:unit) = React.Step.execute step in 
+        
+        if List.length in_fds' = 0  && List.length out_fds' = 0 
+        then Timeout 
+        else Event_happened  
+
+let nb_of_writes selector = 
+    let {out_fds; _ } = !selector in 
+    List.length out_fds

--- a/react_forked_event/select.mli
+++ b/react_forked_event/select.mli
@@ -1,0 +1,38 @@
+
+
+
+
+type selector 
+
+val create : unit -> selector 
+(** [create ()] returns a new empty selector object *)
+
+val add_in : Unix.file_descr -> selector -> Unix.file_descr React.event
+(** [add fd selector] returns an [event] which occurence indicates the file
+    descriptor has data to be read. 
+ *) 
+
+val remove_in : Unix.file_descr -> selector -> unit 
+
+val add_out: Unix.file_descr -> selector -> Unix.file_descr React.event
+(** [add fd selector] returns an [event] which occurence indicates the file
+    descriptor can be written to. 
+ *) 
+
+val remove_out : Unix.file_descr -> selector -> unit 
+
+type select_status = 
+    | Timeout 
+    | Event_happened 
+    | No_fds
+
+val select : float -> selector -> select_status 
+(** [select timeout] will wait until either [timeout] seconds has happened or
+    until an event happened on one of the [Unix.file_descr] added to the
+    selector. 
+
+    In case one or more event happens the corresponding [React.event] are
+    triggered
+  *)
+
+val nb_of_writes : selector -> int 


### PR DESCRIPTION
This commit adds the combine use of React event model with  the `Unix.select` command. 
A new `select` api is implemented which output are modeled with either read event or writes. 
The current implementation assumes that the software is single threaded and the main function is a loop over the new `select` api. It allows read/write of any sizes with any number of children.