### PR TITLE
Refactor OCaml variant type

### DIFF
--- a/protobuf_parser/exception.ml
+++ b/protobuf_parser/exception.ml
@@ -4,12 +4,10 @@
 module P = Printf
 
 type programmatic_error =
-  | Recursive_one_of 
   | Invalid_string_split 
   | Unexpect_field_type 
 
 let string_of_programmatic_error = function 
-  | Recursive_one_of     -> "recursive one of"
   | Invalid_string_split -> "string split error"
   | Unexpect_field_type  -> "unexpected field type"
 

--- a/protobuf_parser/exception.mli
+++ b/protobuf_parser/exception.mli
@@ -1,6 +1,5 @@
 
 type programmatic_error =
-  | Recursive_one_of 
   | Invalid_string_split 
   | Unexpect_field_type 
 

--- a/protobuf_parser/test.ml
+++ b/protobuf_parser/test.ml
@@ -659,9 +659,9 @@ let () =
         variant_name  = "m1_o1"; 
         constructors = [
           {field_type = Int; field_name = "Intv"; type_qualifier = No_qualifier;
-           encoding_type = Regular_field {field_number = 1; payload_kind = Encoding_util.Varint false}};
+           encoding_type = {field_number = 1; payload_kind = Encoding_util.Varint false}};
           {field_type = String; field_name = "Stringv"; type_qualifier = No_qualifier;
-           encoding_type = Regular_field {field_number = 2; payload_kind = Encoding_util.Bytes}};
+           encoding_type = {field_number = 2; payload_kind = Encoding_util.Bytes}};
         ];
       }) in
     assert(BO.Variant variant = List.nth ocaml_types 0);


### PR DESCRIPTION
* Previous variant definition allowed for recursive One_of encoding
  which is not possible in the protobuffer protocol. The variant
  type definition now enforces this.
* Remove corresponding programmatic error exception which previously
  captured this invariant violation.